### PR TITLE
Lazy Evaluation of Tensors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-    "python.analysis.typeCheckingMode": "off"
+    "python.analysis.typeCheckingMode": "off",
+    "python.formatting.provider": "black",
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    }
 }

--- a/src/autograd.ts
+++ b/src/autograd.ts
@@ -32,7 +32,7 @@ export type GradientFunction = (
 ) => (Tensor | null)[];
 
 export interface IAutoFunction {
-    forward(inputs: FunctionInput[], output?: Tensor): Tensor;
+    forward(inputs: FunctionInput[]): Tensor;
     apply(...inputs: FunctionInput[]): Tensor;
     backward(
         ctx: GradientContext,

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -617,7 +617,7 @@ export type CompiledExpr = (env: { [name: string]: any }) => number;
 
 export function compileCode(code: ExprCode): CompiledExpr {
     if (typeof code === "number") {
-        return () => code;
+        return (env: EvalEnv) => code;
     }
     const expr = parseCode(code);
     // console.log("parsed", expr);

--- a/src/functions_opgen.ts
+++ b/src/functions_opgen.ts
@@ -7,13 +7,13 @@ import {
 import type { Tensor } from "./tensor";
 import { shapeSize } from "./shape";
 export class AbsFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("abs", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("abs", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -32,13 +32,13 @@ export class AbsFunction extends AutoFunction {
     }
 }
 export class AcosFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("acos", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("acos", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -57,13 +57,13 @@ export class AcosFunction extends AutoFunction {
     }
 }
 export class AcoshFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("acosh", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("acosh", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -82,7 +82,7 @@ export class AcoshFunction extends AutoFunction {
     }
 }
 export class AddFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other, alpha] = inputs as [Tensor, Tensor, number | undefined];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -120,13 +120,13 @@ export class AddFunction extends AutoFunction {
     }
 }
 export class AsinFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("asin", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("asin", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -145,13 +145,13 @@ export class AsinFunction extends AutoFunction {
     }
 }
 export class AsinhFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("asinh", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("asinh", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -170,13 +170,13 @@ export class AsinhFunction extends AutoFunction {
     }
 }
 export class AtanFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("atan", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("atan", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -195,7 +195,7 @@ export class AtanFunction extends AutoFunction {
     }
 }
 export class Atan2Function extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other] = inputs as [Tensor, Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -229,13 +229,13 @@ export class Atan2Function extends AutoFunction {
     }
 }
 export class CeilFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("ceil", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("ceil", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -254,7 +254,7 @@ export class CeilFunction extends AutoFunction {
     }
 }
 export class CopysignFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other] = inputs as [Tensor, Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -288,13 +288,13 @@ export class CopysignFunction extends AutoFunction {
     }
 }
 export class CosFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("cos", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("cos", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -313,13 +313,13 @@ export class CosFunction extends AutoFunction {
     }
 }
 export class CoshFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("cosh", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("cosh", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -338,13 +338,13 @@ export class CoshFunction extends AutoFunction {
     }
 }
 export class Deg2radFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("deg2rad", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("deg2rad", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -363,7 +363,7 @@ export class Deg2radFunction extends AutoFunction {
     }
 }
 export class DivFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other] = inputs as [Tensor, Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -397,13 +397,13 @@ export class DivFunction extends AutoFunction {
     }
 }
 export class ExpFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("exp", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("exp", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -422,13 +422,13 @@ export class ExpFunction extends AutoFunction {
     }
 }
 export class Exp2Function extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("exp2", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("exp2", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -447,13 +447,13 @@ export class Exp2Function extends AutoFunction {
     }
 }
 export class Expm1Function extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("expm1", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("expm1", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -472,13 +472,13 @@ export class Expm1Function extends AutoFunction {
     }
 }
 export class FloorFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("floor", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("floor", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -497,13 +497,13 @@ export class FloorFunction extends AutoFunction {
     }
 }
 export class FracFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("frac", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("frac", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -522,7 +522,7 @@ export class FracFunction extends AutoFunction {
     }
 }
 export class HypotFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other] = inputs as [Tensor, Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -556,7 +556,7 @@ export class HypotFunction extends AutoFunction {
     }
 }
 export class LdexpFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other] = inputs as [Tensor, Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -590,13 +590,13 @@ export class LdexpFunction extends AutoFunction {
     }
 }
 export class LogFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("log", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("log", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -615,13 +615,13 @@ export class LogFunction extends AutoFunction {
     }
 }
 export class Log10Function extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("log10", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("log10", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -640,13 +640,13 @@ export class Log10Function extends AutoFunction {
     }
 }
 export class Log1pFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("log1p", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("log1p", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -665,13 +665,13 @@ export class Log1pFunction extends AutoFunction {
     }
 }
 export class Log2Function extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("log2", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("log2", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -690,7 +690,7 @@ export class Log2Function extends AutoFunction {
     }
 }
 export class LogaddexpFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other] = inputs as [Tensor, Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -724,7 +724,7 @@ export class LogaddexpFunction extends AutoFunction {
     }
 }
 export class Logaddexp2Function extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other] = inputs as [Tensor, Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -758,7 +758,7 @@ export class Logaddexp2Function extends AutoFunction {
     }
 }
 export class MulFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other] = inputs as [Tensor, Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -792,13 +792,13 @@ export class MulFunction extends AutoFunction {
     }
 }
 export class NegFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("neg", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("neg", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -817,13 +817,13 @@ export class NegFunction extends AutoFunction {
     }
 }
 export class PositiveFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("positive", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("positive", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -842,7 +842,7 @@ export class PositiveFunction extends AutoFunction {
     }
 }
 export class PowFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other] = inputs as [Tensor, Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -876,13 +876,13 @@ export class PowFunction extends AutoFunction {
     }
 }
 export class Rad2degFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("rad2deg", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("rad2deg", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -901,13 +901,13 @@ export class Rad2degFunction extends AutoFunction {
     }
 }
 export class ReciprocalFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("reciprocal", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("reciprocal", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -926,13 +926,13 @@ export class ReciprocalFunction extends AutoFunction {
     }
 }
 export class ReluFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("relu", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("relu", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -951,13 +951,13 @@ export class ReluFunction extends AutoFunction {
     }
 }
 export class RoundFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("round", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("round", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -976,13 +976,13 @@ export class RoundFunction extends AutoFunction {
     }
 }
 export class RsqrtFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("rsqrt", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("rsqrt", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1001,13 +1001,13 @@ export class RsqrtFunction extends AutoFunction {
     }
 }
 export class SigmoidFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("sigmoid", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("sigmoid", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1026,13 +1026,13 @@ export class SigmoidFunction extends AutoFunction {
     }
 }
 export class SignFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("sign", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("sign", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1051,13 +1051,13 @@ export class SignFunction extends AutoFunction {
     }
 }
 export class SiluFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("silu", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("silu", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1076,13 +1076,13 @@ export class SiluFunction extends AutoFunction {
     }
 }
 export class SinFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("sin", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("sin", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1101,13 +1101,13 @@ export class SinFunction extends AutoFunction {
     }
 }
 export class SincFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("sinc", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("sinc", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1126,13 +1126,13 @@ export class SincFunction extends AutoFunction {
     }
 }
 export class SinhFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("sinh", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("sinh", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1151,13 +1151,13 @@ export class SinhFunction extends AutoFunction {
     }
 }
 export class SqrtFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("sqrt", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("sqrt", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1176,13 +1176,13 @@ export class SqrtFunction extends AutoFunction {
     }
 }
 export class SquareFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("square", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("square", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1201,7 +1201,7 @@ export class SquareFunction extends AutoFunction {
     }
 }
 export class SubFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other, alpha] = inputs as [Tensor, Tensor, number | undefined];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -1239,13 +1239,13 @@ export class SubFunction extends AutoFunction {
     }
 }
 export class TanFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("tan", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("tan", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1264,13 +1264,13 @@ export class TanFunction extends AutoFunction {
     }
 }
 export class TanhFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("tanh", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("tanh", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1289,13 +1289,13 @@ export class TanhFunction extends AutoFunction {
     }
 }
 export class TruncFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input] = inputs as [Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         const params = {
             size: shapeSize(input.shape),
         };
-        return input.runKernel("trunc", {"dtype":"float32"}, params, output ? [output] : [input.shape])[0];
+        return input.runKernel("trunc", {"dtype":"float32"}, params, [input.shape])[0];
     }
     static setupContext(
         ctx: GradientContext,
@@ -1314,7 +1314,7 @@ export class TruncFunction extends AutoFunction {
     }
 }
 export class XlogyFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, other] = inputs as [Tensor, Tensor];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (typeof other === "number") {
@@ -1348,7 +1348,7 @@ export class XlogyFunction extends AutoFunction {
     }
 }
 export class AllFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, dim, keepdim] = inputs as [Tensor, number | number[] | undefined, boolean | undefined];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (dim !== undefined) {
@@ -1401,7 +1401,7 @@ export class AllFunction extends AutoFunction {
     }
 }
 export class AnyFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, dim, keepdim] = inputs as [Tensor, number | number[] | undefined, boolean | undefined];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (dim !== undefined) {
@@ -1454,7 +1454,7 @@ export class AnyFunction extends AutoFunction {
     }
 }
 export class MeanFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, dim, keepdim] = inputs as [Tensor, number | number[] | undefined, boolean | undefined];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (dim !== undefined) {
@@ -1507,7 +1507,7 @@ export class MeanFunction extends AutoFunction {
     }
 }
 export class NormFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, dim, keepdim] = inputs as [Tensor, number | number[] | undefined, boolean | undefined];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (dim !== undefined) {
@@ -1560,7 +1560,7 @@ export class NormFunction extends AutoFunction {
     }
 }
 export class ProdFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, dim, keepdim] = inputs as [Tensor, number | number[] | undefined, boolean | undefined];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (dim !== undefined) {
@@ -1613,7 +1613,7 @@ export class ProdFunction extends AutoFunction {
     }
 }
 export class SumFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, dim, keepdim] = inputs as [Tensor, number | number[] | undefined, boolean | undefined];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (dim !== undefined) {
@@ -1666,7 +1666,7 @@ export class SumFunction extends AutoFunction {
     }
 }
 export class CountNonzeroFunction extends AutoFunction {
-    static forward(inputs: FunctionInput[], output?: Tensor): Tensor {
+    static forward(inputs: FunctionInput[]): Tensor {
         const [input, dim, keepdim] = inputs as [Tensor, number | number[] | undefined, boolean | undefined];
         if (!input.isContiguous) { throw new Error("Input must be contiguous"); }
         if (dim !== undefined) {

--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -31,3 +31,13 @@ test("deep equal-width graphs use minimal buffers", async () => {
     const node = y.node.node as ComputedNode;
     expect(node.inputs).toEqual([ys[depth - 2].node]);
 });
+
+test("inplace ops handled correctly", async () => {
+    const x = tensor([1, 2, 3]);
+    const y = x.neg();
+    x.neg_();
+    const z = x.neg();
+    expect(await x.toArrayAsync()).toEqual([-1, -2, -3]);
+    expect(await y.toArrayAsync()).toEqual([-1, -2, -3]);
+    expect(await z.toArrayAsync()).toEqual([1, 2, 3]);
+});

--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -41,3 +41,24 @@ test("inplace ops handled correctly", async () => {
     expect(await y.toArrayAsync()).toEqual([-1, -2, -3]);
     expect(await z.toArrayAsync()).toEqual([1, 2, 3]);
 });
+
+test("temporaries are not retained", async () => {
+    const x = tensor([1, 2, 3]);
+    const y = x.neg();
+    const z = y.neg();
+    expect(await z.toArrayAsync()).toEqual([1, 2, 3]);
+    expect(y.node.node.storageAvailable).toEqual(false);
+    expect(z.node.node.storageAvailable).toEqual(true);
+});
+
+test("aliases are retained", async () => {
+    const x = tensor([1, 2, 3]);
+    const y = x.neg();
+    const z = y.neg();
+    const w = y.neg();
+    expect(await z.toArrayAsync()).toEqual([1, 2, 3]);
+    expect(await w.toArrayAsync()).toEqual([1, 2, 3]);
+    expect(y.node.node.storageAvailable).toEqual(true);
+    expect(z.node.node.storageAvailable).toEqual(true);
+    expect(w.node.node.storageAvailable).toEqual(true);
+});

--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -4,16 +4,16 @@ import { Tensor } from "./tensor";
 
 test("array tensors are source nodes", async () => {
     const x = tensor([1, 2, 3]);
-    expect(x.node.isSource).toBe(true);
-    expect(await x.node.storage.toArrayAsync(x.dtype)).toEqual([1, 2, 3]);
+    expect(x.node.node.isSource).toBe(true);
+    expect(await x.node.node.storages[0].toArrayAsync(x.dtype)).toEqual([1, 2, 3]);
 });
 
 test("unop tensors are computed nodes", async () => {
     const x = tensor([1, 2, 3]);
     const y = x.neg();
-    expect(y.node.isComputed).toBe(true);
-    expect(await y.node.storage.toArrayAsync(y.dtype)).toEqual([-1, -2, -3]);
-    const node = y.node as ComputedNode;
+    expect(y.node.node.isComputed).toBe(true);
+    expect(await y.node.node.storages[0].toArrayAsync(y.dtype)).toEqual([-1, -2, -3]);
+    const node = y.node.node as ComputedNode;
     expect(node.inputs).toEqual([x.node]);
 });
 
@@ -26,8 +26,8 @@ test("deep equal-width graphs use minimal buffers", async () => {
         y = y.neg();
         ys.push(y);
     }
-    expect(y.node.isComputed).toBe(true);
-    expect(await y.node.storage.toArrayAsync(y.dtype)).toEqual([-1, -2, -3]);
-    const node = y.node as ComputedNode;
+    expect(y.node.node.isComputed).toBe(true);
+    expect(await y.node.node.storages[0].toArrayAsync(y.dtype)).toEqual([-1, -2, -3]);
+    const node = y.node.node as ComputedNode;
     expect(node.inputs).toEqual([ys[depth - 2].node]);
 });

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -157,7 +157,11 @@ export class ComputedNode extends GraphNode {
                 }
                 return inputS;
             });
-            const outputs = this.outputs.map(output => alloc(dtypeByteSize(output.dtype) * shapeSize(output.shape)));
+            const outputs = this.outputs.map((output, i) => {
+                // output size = dtypeByteSize(output.dtype) * shapeSize(output.shape)
+                const outputByteSize = this.kernel.eval(this.kernel.spec.outputs[i].size, this.params) * dtypeByteSize(output.dtype);
+                return alloc(outputByteSize);
+            });
             this.kernel.run(inputs, this.params, outputs);
             computedStorages[nodeId] = outputs;
             // Free any nodes that are not live anymore.

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -180,13 +180,11 @@ export class ComputedNode extends GraphNode {
                 }
                 return inputS;
             });
-            const outputs = this.outputs.map((output, i) => {
-                // output size = dtypeByteSize(output.dtype) * shapeSize(output.shape)
+            const [nodeRunEnv, paramValues] = node.kernel.getRunEnv(node.params);
+            const outputs = node.outputs.map((output, i) => {
                 const outputByteSize =
-                    this.kernel.eval(
-                        this.kernel.spec.outputs[i].size,
-                        this.params
-                    ) * dtypeByteSize(output.dtype);
+                    node.kernel.spec.outputs[i].size(nodeRunEnv) *
+                    dtypeByteSize(output.dtype);
                 return alloc(outputByteSize);
             });
             node.kernel.run(inputs, node.params, outputs);

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -189,7 +189,7 @@ export class ComputedNode extends GraphNode {
                     ) * dtypeByteSize(output.dtype);
                 return alloc(outputByteSize);
             });
-            node.kernel.run(inputs, this.params, outputs);
+            node.kernel.run(inputs, node.params, outputs);
             computedStorages[nodeId] = outputs;
             // Free any nodes that are not live anymore.
             for (let inLiveId of liveness.ins[i]) {

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -105,6 +105,11 @@ export abstract class Kernel {
         outputs?: UntypedStorage[]
     ): UntypedStorage[];
 
+    eval(expr: ExprCode, parameters: KernelParamsInput): number {
+        const [env, paramValues] = this.getRunEnv(parameters);
+        return evalCode(expr, env);
+    }
+
     protected getRunEnv(parameters: KernelParamsInput): [EvalEnv, number[]] {
         const env: EvalEnv = Object.assign({}, this._configEnv);
         const paramValues: number[] = [];

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -4,9 +4,15 @@ import type { Device } from "./device";
 import type { ATypedArray, Dtype } from "./dtype";
 import type { UntypedStorage } from "./storage";
 
-export type ShaderDynamicArrayType = "array<u8>" | "array<i32>" | "array<u32>" | "array<f32>";
+export type ShaderDynamicArrayType =
+    | "array<u8>"
+    | "array<i32>"
+    | "array<u32>"
+    | "array<f32>";
 
-export type ShaderArrayType = ShaderDynamicArrayType | [ShaderDynamicArrayType, number];
+export type ShaderArrayType =
+    | ShaderDynamicArrayType
+    | [ShaderDynamicArrayType, number];
 
 export type ShaderType =
     | "u8"
@@ -30,6 +36,18 @@ export interface KernelSpec {
     shader: string;
 }
 
+export interface KernelCompiledSpec {
+    name: string;
+    config: KernelConfigSpec[];
+    workgroupSize: [CompiledExpr, CompiledExpr, CompiledExpr];
+    parameters: KernelParamSpec[];
+    workgroupCount: [CompiledExpr, CompiledExpr, CompiledExpr];
+    workgroupVariables?: KernelInputSpec[];
+    inputs: KernelInputSpec[];
+    outputs: KernelOutputCompiledSpec[];
+    shader: string;
+}
+
 export interface KernelInputSpec {
     name: string;
     shaderType: ShaderType;
@@ -39,6 +57,12 @@ export interface KernelOutputSpec {
     name: string;
     shaderType: ShaderType;
     size: ExprCode;
+}
+
+export interface KernelOutputCompiledSpec {
+    name: string;
+    shaderType: ShaderType;
+    size: CompiledExpr;
 }
 
 export interface KernelParamSpec {
@@ -57,18 +81,14 @@ export type KernelKey = string;
 
 export abstract class Kernel {
     private _key: KernelKey;
-    private _spec: KernelSpec;
+    protected _spec: KernelCompiledSpec;
     private _config: KernelConfig;
     private _device: Device;
-    private _workgroupCountXFunc: CompiledExpr;
-    private _workgroupCountYFunc: CompiledExpr;
-    private _workgroupCountZFunc: CompiledExpr;
-    protected _outputSizeFuncs: CompiledExpr[];
     private _configEnv: EvalEnv;
     get key(): KernelKey {
         return this._key;
     }
-    get spec(): KernelSpec {
+    get spec(): KernelCompiledSpec {
         return this._spec;
     }
     get config(): KernelConfig {
@@ -77,21 +97,17 @@ export abstract class Kernel {
     get device(): Device {
         return this._device;
     }
-    constructor(spec: KernelSpec, config: KernelConfig, device: Device) {
+    protected constructor(
+        spec: KernelSpec,
+        config: KernelConfig,
+        device: Device,
+        baseEnv: EvalEnv
+    ) {
         this._key = getKernelKey(spec, config);
         this._device = device;
-        this._spec = spec;
+        this._spec = compileKernelSpec(spec);
         this._config = config;
-        this._workgroupCountXFunc = compileCode(spec.workgroupCount[0]);
-        this._workgroupCountYFunc = compileCode(spec.workgroupCount[1]);
-        this._workgroupCountZFunc = compileCode(spec.workgroupCount[2]);
-        this._outputSizeFuncs = [];
-        for (let i = 0; i < this._spec.outputs.length; i++) {
-            const outputSpec = this._spec.outputs[i];
-            const outputElementCount = compileCode(outputSpec.size);
-            this._outputSizeFuncs.push(outputElementCount);
-        }
-        this._configEnv = Object.assign({}, jsMathEnv);
+        this._configEnv = Object.assign({}, baseEnv);
         for (let i = 0; i < this._spec.config.length; i++) {
             const configSpec = this._spec.config[i];
             const configValue = this._config[i];
@@ -105,19 +121,16 @@ export abstract class Kernel {
         outputs?: UntypedStorage[]
     ): UntypedStorage[];
 
-    eval(expr: ExprCode, parameters: KernelParamsInput): number {
-        const [env, paramValues] = this.getRunEnv(parameters);
-        return evalCode(expr, env);
-    }
-
-    protected getRunEnv(parameters: KernelParamsInput): [EvalEnv, number[]] {
+    public getRunEnv(parameters: KernelParamsInput): [EvalEnv, number[]] {
         const env: EvalEnv = Object.assign({}, this._configEnv);
         const paramValues: number[] = [];
         for (let i = 0; i < this.spec.parameters.length; i++) {
             const param = this.spec.parameters[i];
             const paramValue = parameters[param.name];
             if (paramValue === undefined) {
-                throw new Error(`Missing parameter \"${param.name}\" for kernel \"${this.spec.name}\"`);
+                throw new Error(
+                    `Missing parameter \"${param.name}\" for kernel \"${this.spec.name}\"`
+                );
             }
             paramValues.push(paramValue);
             env[param.name] = paramValue;
@@ -126,9 +139,9 @@ export abstract class Kernel {
     }
 
     getWorkgroupCounts(env: EvalEnv): [number, number, number] {
-        const workgroupCountX = Math.ceil(this._workgroupCountXFunc(env));
-        const workgroupCountY = Math.ceil(this._workgroupCountYFunc(env));
-        const workgroupCountZ = Math.ceil(this._workgroupCountZFunc(env));
+        const workgroupCountX = Math.ceil(this._spec.workgroupCount[0](env));
+        const workgroupCountY = Math.ceil(this._spec.workgroupCount[1](env));
+        const workgroupCountZ = Math.ceil(this._spec.workgroupCount[2](env));
         if (workgroupCountX > this.device.workgroupMaxCount) {
             throw new Error(
                 `Workgroup count X (${workgroupCountX}) exceeds the maximum allowed value (${this.device.workgroupMaxCount})`
@@ -149,12 +162,31 @@ export abstract class Kernel {
     }
 }
 
-const jsMathEnv: EvalEnv = {};
-for (const name of Object.getOwnPropertyNames(Math)) {
-    const f = (Math as any)[name];
-    if (typeof f === "function") {
-        jsMathEnv[name] = f;
-    }
+function compileKernelSpec(spec: KernelSpec): KernelCompiledSpec {
+    return {
+        name: spec.name,
+        parameters: spec.parameters,
+        config: spec.config,
+        shader: spec.shader,
+        workgroupCount: spec.workgroupCount.map(x => compileCode(x)) as [
+            CompiledExpr,
+            CompiledExpr,
+            CompiledExpr
+        ],
+        workgroupSize: spec.workgroupSize.map(x => compileCode(x)) as [
+            CompiledExpr,
+            CompiledExpr,
+            CompiledExpr
+        ],
+        inputs: spec.inputs,
+        outputs: spec.outputs.map((outputSpec) => {
+            return {
+                name: outputSpec.name,
+                shaderType: outputSpec.shaderType,
+                size: compileCode(outputSpec.size),
+            };
+        }),
+    };
 }
 
 export function getKernelConfig(
@@ -256,13 +288,13 @@ function configShader(
 export function shaderTypeToCode(shaderType: ShaderType): string {
     if (typeof shaderType === "string") {
         return shaderType;
-    } if (shaderType instanceof Array) {
+    }
+    if (shaderType instanceof Array) {
         return shaderType[0].replace(">", ", " + shaderType[1] + ">");
     } else {
         throw new Error(`Unknown shader type ${shaderType}`);
     }
 }
-
 
 export function getKernelShaderCode(
     spec: KernelSpec,
@@ -301,10 +333,20 @@ export function getKernelShaderCode(
             );
         }
     }
-    const [workgroupMaxSizeX, workgroupMaxSizeY, workgroupMaxSizeZ] = device.workgroupMaxSize;
-    const workgroupSizeX = Math.min(workgroupMaxSizeX, Math.ceil(evalCode(spec.workgroupSize[0], env)));
-    const workgroupSizeY = Math.min(workgroupMaxSizeY, Math.ceil(evalCode(spec.workgroupSize[1], env)));
-    const workgroupSizeZ = Math.min(workgroupMaxSizeZ, Math.ceil(evalCode(spec.workgroupSize[2], env)));
+    const [workgroupMaxSizeX, workgroupMaxSizeY, workgroupMaxSizeZ] =
+        device.workgroupMaxSize;
+    const workgroupSizeX = Math.min(
+        workgroupMaxSizeX,
+        Math.ceil(evalCode(spec.workgroupSize[0], env))
+    );
+    const workgroupSizeY = Math.min(
+        workgroupMaxSizeY,
+        Math.ceil(evalCode(spec.workgroupSize[1], env))
+    );
+    const workgroupSizeZ = Math.min(
+        workgroupMaxSizeZ,
+        Math.ceil(evalCode(spec.workgroupSize[2], env))
+    );
     shaderCodeParts.push(
         `@compute @workgroup_size(${workgroupSizeX}, ${workgroupSizeY}, ${workgroupSizeZ})`
     );
@@ -340,14 +382,17 @@ const javaScriptSubstitutions: [RegExp, string][] = [
     ["local_id\\.x", "local_id_x"],
     ["local_id\\.y", "local_id_y"],
     ["local_id\\.z", "local_id_z"],
-    ["workgroupBarrier\\s*\\(\\s*\\)\\s*;", "yield \"workgroupBarrier\";"],
-    ["storageBarrier\\s*\\(\\s*\\)\\s*;", "yield \"storageBarrier\";"],
+    ["workgroupBarrier\\s*\\(\\s*\\)\\s*;", 'yield "workgroupBarrier";'],
+    ["storageBarrier\\s*\\(\\s*\\)\\s*;", 'yield "storageBarrier";'],
 ].map(([regex, replacement]) => [new RegExp(regex, "g"), replacement]);
 
 // Add all the Math. functions to the substitution list
 for (const name of Object.getOwnPropertyNames(Math)) {
     if (typeof (Math as any)[name] === "function") {
-        javaScriptSubstitutions.push([new RegExp(`\\b${name}\\(`, "g"), `Math.${name}(`]);
+        javaScriptSubstitutions.push([
+            new RegExp(`\\b${name}\\(`, "g"),
+            `Math.${name}(`,
+        ]);
     }
 }
 
@@ -502,7 +547,9 @@ export function getKernelJavaScriptCode(
         w.writeLine(`while (!allDone) {`);
         w.indent();
         w.writeLine(`allDone = true;`);
-        w.writeLine(`for (let local_index = 0; local_index < ${workgroupSize}; local_index++) {`);
+        w.writeLine(
+            `for (let local_index = 0; local_index < ${workgroupSize}; local_index++) {`
+        );
         w.indent();
         w.writeLine(`const barrier = barriers[local_index];`);
         w.writeLine(`const barrierValue = barrier.next();`);

--- a/src/kernel_cpu.ts
+++ b/src/kernel_cpu.ts
@@ -113,7 +113,7 @@ export class KernelCPU extends Kernel {
                 return providedOutput;
             }
             throw new Error(
-                `Output buffer #${outputIndex} (out of ${this.spec.outputs.length}) named "${outputSpec.name}" in kernel "${this.key}" is not an ArrayBufferStorage`
+                `Output buffer #${outputIndex} (out of ${this.spec.outputs.length}) named "${outputSpec.name}" in kernel "${this.key}" is not an ArrayBufferStorage. It's a ${providedOutput.constructor.name}`
             );
         } else {
             const outputElementByteSize = getShaderTypeElementByteSize(

--- a/src/kernel_cpu.ts
+++ b/src/kernel_cpu.ts
@@ -30,6 +30,11 @@ export class KernelCPU extends Kernel {
         outputs?: UntypedStorage[]
     ): UntypedStorage[] {
         // console.log("run cpu kernel", this.key);
+        if (inputs.length !== this.spec.inputs.length) {
+            throw new Error(
+                `Expected ${this.spec.inputs.length} inputs for kernel \"${this.spec.name}\", got ${inputs.length}`
+            );
+        }
 
         // Build the parameter environment
         const [env, paramValues] = this.getRunEnv(parameters);
@@ -42,7 +47,7 @@ export class KernelCPU extends Kernel {
         this.spec.inputs.forEach((input, i) => {
             const o = this.getStorageInputBuffer(
                 input,
-                inputs[i] ? inputs[i] : null,
+                inputs[i],
                 i,
                 env
             );
@@ -85,15 +90,10 @@ export class KernelCPU extends Kernel {
 
     private getStorageInputBuffer(
         inputSpec: KernelInputSpec,
-        providedInput: UntypedStorage | null,
+        providedInput: UntypedStorage,
         inputIndex: number,
         env: EvalEnv
     ): ArrayBufferStorage {
-        if (providedInput === null) {
-            throw new Error(
-                `Missing input buffer #${inputIndex} (out of ${this.spec.inputs.length}) named "${inputSpec.name}" in kernel "${this.key}"`
-            );
-        }
         if (providedInput instanceof ArrayBufferStorage) {
             return providedInput;
         }

--- a/src/kernel_webgpu.ts
+++ b/src/kernel_webgpu.ts
@@ -5,6 +5,7 @@ import {
     Kernel,
     KernelConfig,
     KernelInputSpec,
+    KernelOutputCompiledSpec,
     KernelOutputSpec,
     KernelParamsInput,
     KernelSpec,
@@ -21,7 +22,7 @@ export class KernelWebGPU extends Kernel {
     private _runId: number = 0;
 
     constructor(spec: KernelSpec, config: KernelConfig, device: Device) {
-        super(spec, config, device);
+        super(spec, config, device, {});
         const gpuDevice = (device as DeviceWebGPU).gpuDevice;
         if (!gpuDevice) {
             throw new Error("Cannot create a GPU kernel without a GPU device");
@@ -204,7 +205,7 @@ export class KernelWebGPU extends Kernel {
         return providedInput;
     }
     private getStorageOutputBuffer(
-        outputSpec: KernelOutputSpec,
+        outputSpec: KernelOutputCompiledSpec,
         providedOutput: UntypedStorage | null,
         outputIndex: number,
         env: EvalEnv
@@ -224,7 +225,7 @@ export class KernelWebGPU extends Kernel {
                 outputSpec.shaderType
             );
             const outputElementCount = Math.ceil(
-                this._outputSizeFuncs[outputIndex](env)
+                this._spec.outputs[outputIndex].size(env)
             );
             // console.log("output size", outputElementCount, outputElementByteSize);
             const outputBufferSize = outputElementByteSize * outputElementCount;
@@ -234,7 +235,7 @@ export class KernelWebGPU extends Kernel {
             //     usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
             // });
             // return outputBuffer;
-            const outputHeapBuffer = this.device.heapAlloc(outputBufferSize);
+            const outputHeapBuffer = this.device.alloc(outputBufferSize);
             return outputHeapBuffer;
         }
     }

--- a/src/ops.test.ts
+++ b/src/ops.test.ts
@@ -57,12 +57,3 @@ test("mean vector grad", async () => {
     const a = await x.grad!.toArrayAsync();
     expect(a).toEqual([0.25, 0.25, 0.25, 0.25]);
 });
-
-test("unary with output", async () => {
-    const x = tensor([1, 2, 3]);
-    const y = tensor([0, 0, 0]);
-    const yy = x.neg(y);
-    const a = await y.toArrayAsync();
-    expect(a).toEqual([-1, -2, -3]);
-    expect(yy).toBe(y);
-});

--- a/src/ops_artisanal.ts
+++ b/src/ops_artisanal.ts
@@ -130,5 +130,8 @@ export function tensor(
     device?: Deviceish,
     requiresGrad?: boolean
 ): Tensor {
-    return new Tensor(arrayOrSpec, dtype, device, requiresGrad);
+    if (arrayOrSpec.hasOwnProperty("data")) {
+        return new Tensor(arrayOrSpec as TensorSpec);
+    }
+    return new Tensor(arrayOrSpec as TensorData, dtype, device, requiresGrad);
 }

--- a/src/ops_high.ts
+++ b/src/ops_high.ts
@@ -3,14 +3,11 @@
 import { IAutoFunction, shouldCreateGradient } from "./autograd";
 import type { Tensor } from "./tensor";
 
-export function unary(func: IAutoFunction, input: Tensor, output?: Tensor): Tensor {
+export function unary(func: IAutoFunction, input: Tensor): Tensor {
     if (shouldCreateGradient(input)) {
-        if (output !== undefined) {
-            throw new Error("Cannot specify output tensor when creating gradient");
-        }
         return func.apply(input);
     }
-    return func.forward([input], output);
+    return func.forward([input]);
 }
 
 export function unaryWithAlpha(func: IAutoFunction, input: Tensor, alpha?: number): Tensor {

--- a/src/ops_opgen.ts
+++ b/src/ops_opgen.ts
@@ -17,8 +17,8 @@ import { unary, unaryWithAlpha, binary, binaryWithAlpha, reduction } from "./ops
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function abs(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.AbsFunction, input, output);
+export function abs(input: Tensor): Tensor {
+    return unary(functions.AbsFunction, input);
 }
 /**
 * Alias for `abs`.
@@ -38,7 +38,7 @@ export function abs(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function absolute(input: Tensor, output?: Tensor): Tensor {
+export function absolute(input: Tensor): Tensor {
     return abs(input);
 }
 /**
@@ -57,8 +57,8 @@ export function absolute(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function acos(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.AcosFunction, input, output);
+export function acos(input: Tensor): Tensor {
+    return unary(functions.AcosFunction, input);
 }
 /**
 * Alias for `acos`.
@@ -78,7 +78,7 @@ export function acos(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function arccos(input: Tensor, output?: Tensor): Tensor {
+export function arccos(input: Tensor): Tensor {
     return acos(input);
 }
 /**
@@ -97,8 +97,8 @@ export function arccos(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function acosh(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.AcoshFunction, input, output);
+export function acosh(input: Tensor): Tensor {
+    return unary(functions.AcoshFunction, input);
 }
 /**
 * Alias for `acosh`.
@@ -118,7 +118,7 @@ export function acosh(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function arccosh(input: Tensor, output?: Tensor): Tensor {
+export function arccosh(input: Tensor): Tensor {
     return acosh(input);
 }
 /**
@@ -156,8 +156,8 @@ export function add(input: Tensor, other: number | Tensor, alpha?: number): Tens
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function asin(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.AsinFunction, input, output);
+export function asin(input: Tensor): Tensor {
+    return unary(functions.AsinFunction, input);
 }
 /**
 * Alias for `asin`.
@@ -177,7 +177,7 @@ export function asin(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function arcsin(input: Tensor, output?: Tensor): Tensor {
+export function arcsin(input: Tensor): Tensor {
     return asin(input);
 }
 /**
@@ -196,8 +196,8 @@ export function arcsin(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function asinh(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.AsinhFunction, input, output);
+export function asinh(input: Tensor): Tensor {
+    return unary(functions.AsinhFunction, input);
 }
 /**
 * Alias for `asinh`.
@@ -217,7 +217,7 @@ export function asinh(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function arcsinh(input: Tensor, output?: Tensor): Tensor {
+export function arcsinh(input: Tensor): Tensor {
     return asinh(input);
 }
 /**
@@ -236,8 +236,8 @@ export function arcsinh(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function atan(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.AtanFunction, input, output);
+export function atan(input: Tensor): Tensor {
+    return unary(functions.AtanFunction, input);
 }
 /**
 * Alias for `atan`.
@@ -257,7 +257,7 @@ export function atan(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function arctan(input: Tensor, output?: Tensor): Tensor {
+export function arctan(input: Tensor): Tensor {
     return atan(input);
 }
 /**
@@ -314,8 +314,8 @@ export function arctan2(input: Tensor, other: number | Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function ceil(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.CeilFunction, input, output);
+export function ceil(input: Tensor): Tensor {
+    return unary(functions.CeilFunction, input);
 }
 /**
 * Calculates:
@@ -351,8 +351,8 @@ export function copysign(input: Tensor, other: number | Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function cos(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.CosFunction, input, output);
+export function cos(input: Tensor): Tensor {
+    return unary(functions.CosFunction, input);
 }
 /**
 * ![Plot of cosh and its gradient](../../plots/cosh.svg)
@@ -370,8 +370,8 @@ export function cos(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function cosh(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.CoshFunction, input, output);
+export function cosh(input: Tensor): Tensor {
+    return unary(functions.CoshFunction, input);
 }
 /**
 * ![Plot of deg2rad and its gradient](../../plots/deg2rad.svg)
@@ -389,8 +389,8 @@ export function cosh(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function deg2rad(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.Deg2radFunction, input, output);
+export function deg2rad(input: Tensor): Tensor {
+    return unary(functions.Deg2radFunction, input);
 }
 /**
 * Calculates:
@@ -446,8 +446,8 @@ export function divide(input: Tensor, other: number | Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function exp(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.ExpFunction, input, output);
+export function exp(input: Tensor): Tensor {
+    return unary(functions.ExpFunction, input);
 }
 /**
 * ![Plot of exp2 and its gradient](../../plots/exp2.svg)
@@ -465,8 +465,8 @@ export function exp(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function exp2(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.Exp2Function, input, output);
+export function exp2(input: Tensor): Tensor {
+    return unary(functions.Exp2Function, input);
 }
 /**
 * ![Plot of expm1 and its gradient](../../plots/expm1.svg)
@@ -484,8 +484,8 @@ export function exp2(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function expm1(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.Expm1Function, input, output);
+export function expm1(input: Tensor): Tensor {
+    return unary(functions.Expm1Function, input);
 }
 /**
 * ![Plot of floor and its gradient](../../plots/floor.svg)
@@ -503,8 +503,8 @@ export function expm1(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function floor(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.FloorFunction, input, output);
+export function floor(input: Tensor): Tensor {
+    return unary(functions.FloorFunction, input);
 }
 /**
 * ![Plot of frac and its gradient](../../plots/frac.svg)
@@ -522,8 +522,8 @@ export function floor(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function frac(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.FracFunction, input, output);
+export function frac(input: Tensor): Tensor {
+    return unary(functions.FracFunction, input);
 }
 /**
 * Calculates:
@@ -577,8 +577,8 @@ export function ldexp(input: Tensor, other: number | Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function log(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.LogFunction, input, output);
+export function log(input: Tensor): Tensor {
+    return unary(functions.LogFunction, input);
 }
 /**
 * ![Plot of log10 and its gradient](../../plots/log10.svg)
@@ -596,8 +596,8 @@ export function log(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function log10(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.Log10Function, input, output);
+export function log10(input: Tensor): Tensor {
+    return unary(functions.Log10Function, input);
 }
 /**
 * ![Plot of log1p and its gradient](../../plots/log1p.svg)
@@ -615,8 +615,8 @@ export function log10(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function log1p(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.Log1pFunction, input, output);
+export function log1p(input: Tensor): Tensor {
+    return unary(functions.Log1pFunction, input);
 }
 /**
 * ![Plot of log2 and its gradient](../../plots/log2.svg)
@@ -634,8 +634,8 @@ export function log1p(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function log2(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.Log2Function, input, output);
+export function log2(input: Tensor): Tensor {
+    return unary(functions.Log2Function, input);
 }
 /**
 * Calculates:
@@ -727,8 +727,8 @@ export function multiply(input: Tensor, other: number | Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function neg(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.NegFunction, input, output);
+export function neg(input: Tensor): Tensor {
+    return unary(functions.NegFunction, input);
 }
 /**
 * Alias for `neg`.
@@ -748,7 +748,7 @@ export function neg(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function negative(input: Tensor, output?: Tensor): Tensor {
+export function negative(input: Tensor): Tensor {
     return neg(input);
 }
 /**
@@ -767,8 +767,8 @@ export function negative(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function positive(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.PositiveFunction, input, output);
+export function positive(input: Tensor): Tensor {
+    return unary(functions.PositiveFunction, input);
 }
 /**
 * Calculates:
@@ -804,8 +804,8 @@ export function pow(input: Tensor, other: number | Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function rad2deg(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.Rad2degFunction, input, output);
+export function rad2deg(input: Tensor): Tensor {
+    return unary(functions.Rad2degFunction, input);
 }
 /**
 * ![Plot of reciprocal and its gradient](../../plots/reciprocal.svg)
@@ -823,8 +823,8 @@ export function rad2deg(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function reciprocal(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.ReciprocalFunction, input, output);
+export function reciprocal(input: Tensor): Tensor {
+    return unary(functions.ReciprocalFunction, input);
 }
 /**
 * ![Plot of relu and its gradient](../../plots/relu.svg)
@@ -842,8 +842,8 @@ export function reciprocal(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function relu(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.ReluFunction, input, output);
+export function relu(input: Tensor): Tensor {
+    return unary(functions.ReluFunction, input);
 }
 /**
 * ![Plot of round and its gradient](../../plots/round.svg)
@@ -861,8 +861,8 @@ export function relu(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function round(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.RoundFunction, input, output);
+export function round(input: Tensor): Tensor {
+    return unary(functions.RoundFunction, input);
 }
 /**
 * ![Plot of rsqrt and its gradient](../../plots/rsqrt.svg)
@@ -880,8 +880,8 @@ export function round(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function rsqrt(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.RsqrtFunction, input, output);
+export function rsqrt(input: Tensor): Tensor {
+    return unary(functions.RsqrtFunction, input);
 }
 /**
 * ![Plot of sigmoid and its gradient](../../plots/sigmoid.svg)
@@ -899,8 +899,8 @@ export function rsqrt(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function sigmoid(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.SigmoidFunction, input, output);
+export function sigmoid(input: Tensor): Tensor {
+    return unary(functions.SigmoidFunction, input);
 }
 /**
 * ![Plot of sign and its gradient](../../plots/sign.svg)
@@ -918,8 +918,8 @@ export function sigmoid(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function sign(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.SignFunction, input, output);
+export function sign(input: Tensor): Tensor {
+    return unary(functions.SignFunction, input);
 }
 /**
 * ![Plot of silu and its gradient](../../plots/silu.svg)
@@ -937,8 +937,8 @@ export function sign(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function silu(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.SiluFunction, input, output);
+export function silu(input: Tensor): Tensor {
+    return unary(functions.SiluFunction, input);
 }
 /**
 * ![Plot of sin and its gradient](../../plots/sin.svg)
@@ -956,8 +956,8 @@ export function silu(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function sin(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.SinFunction, input, output);
+export function sin(input: Tensor): Tensor {
+    return unary(functions.SinFunction, input);
 }
 /**
 * ![Plot of sinc and its gradient](../../plots/sinc.svg)
@@ -975,8 +975,8 @@ export function sin(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function sinc(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.SincFunction, input, output);
+export function sinc(input: Tensor): Tensor {
+    return unary(functions.SincFunction, input);
 }
 /**
 * ![Plot of sinh and its gradient](../../plots/sinh.svg)
@@ -994,8 +994,8 @@ export function sinc(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function sinh(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.SinhFunction, input, output);
+export function sinh(input: Tensor): Tensor {
+    return unary(functions.SinhFunction, input);
 }
 /**
 * ![Plot of sqrt and its gradient](../../plots/sqrt.svg)
@@ -1013,8 +1013,8 @@ export function sinh(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function sqrt(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.SqrtFunction, input, output);
+export function sqrt(input: Tensor): Tensor {
+    return unary(functions.SqrtFunction, input);
 }
 /**
 * ![Plot of square and its gradient](../../plots/square.svg)
@@ -1032,8 +1032,8 @@ export function sqrt(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function square(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.SquareFunction, input, output);
+export function square(input: Tensor): Tensor {
+    return unary(functions.SquareFunction, input);
 }
 /**
 * Calculates:
@@ -1091,8 +1091,8 @@ export function subtract(input: Tensor, other: number | Tensor, alpha?: number):
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function tan(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.TanFunction, input, output);
+export function tan(input: Tensor): Tensor {
+    return unary(functions.TanFunction, input);
 }
 /**
 * ![Plot of tanh and its gradient](../../plots/tanh.svg)
@@ -1110,8 +1110,8 @@ export function tan(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function tanh(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.TanhFunction, input, output);
+export function tanh(input: Tensor): Tensor {
+    return unary(functions.TanhFunction, input);
 }
 /**
 * ![Plot of trunc and its gradient](../../plots/trunc.svg)
@@ -1129,8 +1129,8 @@ export function tanh(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function trunc(input: Tensor, output?: Tensor): Tensor {
-    return unary(functions.TruncFunction, input, output);
+export function trunc(input: Tensor): Tensor {
+    return unary(functions.TruncFunction, input);
 }
 /**
 * Alias for `trunc`.
@@ -1150,7 +1150,7 @@ export function trunc(input: Tensor, output?: Tensor): Tensor {
 * @param input the input tensor of any shape
 * @returns the output tensor
 */
-export function fix(input: Tensor, output?: Tensor): Tensor {
+export function fix(input: Tensor): Tensor {
     return trunc(input);
 }
 /**

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -229,6 +229,14 @@ export class Tensor extends TensorBase {
         }
     }
 
+    /** Eagerly compute this tensor if it is lazy.
+     * @returns This tensor.
+     */
+    eager(): Tensor {
+        this.node.node.eager();
+        return this;
+    }
+
     runKernelInplace(
         name: string,
         config: KernelConfigInput,
@@ -363,12 +371,12 @@ export class Tensor extends TensorBase {
                     `Gradient can only be implicitly created for scalar outputs`
                 );
             }
-            grad = ones(1);
+            grad = ones(1, this.dtype, this.device);
         }
         if (this.grad) {
-            this.grad.add_(grad);
+            this.grad.add_(grad).eager();
         } else {
-            this.grad = grad;
+            this.grad = grad.eager();
         }
         if (!this._gradFunc || !this._gradCtx) {
             return;

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -437,8 +437,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    abs(output?: Tensor): Tensor {
-        return ops.abs(this, output);
+    abs(): Tensor {
+        return ops.abs(this);
     }
     /**
     * Alias for `abs`.
@@ -457,7 +457,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    absolute(output?: Tensor): Tensor {
+    absolute(): Tensor {
         return ops.abs(this);
     }
     /**
@@ -475,7 +475,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    abs_(output?: Tensor): Tensor {
+    abs_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -496,8 +496,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    acos(output?: Tensor): Tensor {
-        return ops.acos(this, output);
+    acos(): Tensor {
+        return ops.acos(this);
     }
     /**
     * Alias for `acos`.
@@ -516,7 +516,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    arccos(output?: Tensor): Tensor {
+    arccos(): Tensor {
         return ops.acos(this);
     }
     /**
@@ -534,7 +534,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    acos_(output?: Tensor): Tensor {
+    acos_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -555,8 +555,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    acosh(output?: Tensor): Tensor {
-        return ops.acosh(this, output);
+    acosh(): Tensor {
+        return ops.acosh(this);
     }
     /**
     * Alias for `acosh`.
@@ -575,7 +575,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    arccosh(output?: Tensor): Tensor {
+    arccosh(): Tensor {
         return ops.acosh(this);
     }
     /**
@@ -593,7 +593,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    acosh_(output?: Tensor): Tensor {
+    acosh_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -663,8 +663,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    asin(output?: Tensor): Tensor {
-        return ops.asin(this, output);
+    asin(): Tensor {
+        return ops.asin(this);
     }
     /**
     * Alias for `asin`.
@@ -683,7 +683,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    arcsin(output?: Tensor): Tensor {
+    arcsin(): Tensor {
         return ops.asin(this);
     }
     /**
@@ -701,7 +701,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    asin_(output?: Tensor): Tensor {
+    asin_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -722,8 +722,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    asinh(output?: Tensor): Tensor {
-        return ops.asinh(this, output);
+    asinh(): Tensor {
+        return ops.asinh(this);
     }
     /**
     * Alias for `asinh`.
@@ -742,7 +742,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    arcsinh(output?: Tensor): Tensor {
+    arcsinh(): Tensor {
         return ops.asinh(this);
     }
     /**
@@ -760,7 +760,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    asinh_(output?: Tensor): Tensor {
+    asinh_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -781,8 +781,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    atan(output?: Tensor): Tensor {
-        return ops.atan(this, output);
+    atan(): Tensor {
+        return ops.atan(this);
     }
     /**
     * Alias for `atan`.
@@ -801,7 +801,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    arctan(output?: Tensor): Tensor {
+    arctan(): Tensor {
         return ops.atan(this);
     }
     /**
@@ -819,7 +819,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    atan_(output?: Tensor): Tensor {
+    atan_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -904,8 +904,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    ceil(output?: Tensor): Tensor {
-        return ops.ceil(this, output);
+    ceil(): Tensor {
+        return ops.ceil(this);
     }
     /**
     * ![Plot of ceil and its gradient](../../plots/ceil.svg)
@@ -922,7 +922,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    ceil_(output?: Tensor): Tensor {
+    ceil_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -988,8 +988,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    cos(output?: Tensor): Tensor {
-        return ops.cos(this, output);
+    cos(): Tensor {
+        return ops.cos(this);
     }
     /**
     * ![Plot of cos and its gradient](../../plots/cos.svg)
@@ -1006,7 +1006,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    cos_(output?: Tensor): Tensor {
+    cos_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1027,8 +1027,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    cosh(output?: Tensor): Tensor {
-        return ops.cosh(this, output);
+    cosh(): Tensor {
+        return ops.cosh(this);
     }
     /**
     * ![Plot of cosh and its gradient](../../plots/cosh.svg)
@@ -1045,7 +1045,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    cosh_(output?: Tensor): Tensor {
+    cosh_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1066,8 +1066,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    deg2rad(output?: Tensor): Tensor {
-        return ops.deg2rad(this, output);
+    deg2rad(): Tensor {
+        return ops.deg2rad(this);
     }
     /**
     * ![Plot of deg2rad and its gradient](../../plots/deg2rad.svg)
@@ -1084,7 +1084,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    deg2rad_(output?: Tensor): Tensor {
+    deg2rad_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1169,8 +1169,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    exp(output?: Tensor): Tensor {
-        return ops.exp(this, output);
+    exp(): Tensor {
+        return ops.exp(this);
     }
     /**
     * ![Plot of exp and its gradient](../../plots/exp.svg)
@@ -1187,7 +1187,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    exp_(output?: Tensor): Tensor {
+    exp_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1208,8 +1208,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    exp2(output?: Tensor): Tensor {
-        return ops.exp2(this, output);
+    exp2(): Tensor {
+        return ops.exp2(this);
     }
     /**
     * ![Plot of exp2 and its gradient](../../plots/exp2.svg)
@@ -1226,7 +1226,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    exp2_(output?: Tensor): Tensor {
+    exp2_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1247,8 +1247,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    expm1(output?: Tensor): Tensor {
-        return ops.expm1(this, output);
+    expm1(): Tensor {
+        return ops.expm1(this);
     }
     /**
     * ![Plot of expm1 and its gradient](../../plots/expm1.svg)
@@ -1265,7 +1265,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    expm1_(output?: Tensor): Tensor {
+    expm1_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1286,8 +1286,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    floor(output?: Tensor): Tensor {
-        return ops.floor(this, output);
+    floor(): Tensor {
+        return ops.floor(this);
     }
     /**
     * ![Plot of floor and its gradient](../../plots/floor.svg)
@@ -1304,7 +1304,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    floor_(output?: Tensor): Tensor {
+    floor_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1325,8 +1325,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    frac(output?: Tensor): Tensor {
-        return ops.frac(this, output);
+    frac(): Tensor {
+        return ops.frac(this);
     }
     /**
     * ![Plot of frac and its gradient](../../plots/frac.svg)
@@ -1343,7 +1343,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    frac_(output?: Tensor): Tensor {
+    frac_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1454,8 +1454,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    log(output?: Tensor): Tensor {
-        return ops.log(this, output);
+    log(): Tensor {
+        return ops.log(this);
     }
     /**
     * ![Plot of log and its gradient](../../plots/log.svg)
@@ -1472,7 +1472,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    log_(output?: Tensor): Tensor {
+    log_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1493,8 +1493,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    log10(output?: Tensor): Tensor {
-        return ops.log10(this, output);
+    log10(): Tensor {
+        return ops.log10(this);
     }
     /**
     * ![Plot of log10 and its gradient](../../plots/log10.svg)
@@ -1511,7 +1511,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    log10_(output?: Tensor): Tensor {
+    log10_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1532,8 +1532,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    log1p(output?: Tensor): Tensor {
-        return ops.log1p(this, output);
+    log1p(): Tensor {
+        return ops.log1p(this);
     }
     /**
     * ![Plot of log1p and its gradient](../../plots/log1p.svg)
@@ -1550,7 +1550,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    log1p_(output?: Tensor): Tensor {
+    log1p_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1571,8 +1571,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    log2(output?: Tensor): Tensor {
-        return ops.log2(this, output);
+    log2(): Tensor {
+        return ops.log2(this);
     }
     /**
     * ![Plot of log2 and its gradient](../../plots/log2.svg)
@@ -1589,7 +1589,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    log2_(output?: Tensor): Tensor {
+    log2_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1764,8 +1764,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    neg(output?: Tensor): Tensor {
-        return ops.neg(this, output);
+    neg(): Tensor {
+        return ops.neg(this);
     }
     /**
     * Alias for `neg`.
@@ -1784,7 +1784,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    negative(output?: Tensor): Tensor {
+    negative(): Tensor {
         return ops.neg(this);
     }
     /**
@@ -1802,7 +1802,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    neg_(output?: Tensor): Tensor {
+    neg_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1823,8 +1823,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    positive(output?: Tensor): Tensor {
-        return ops.positive(this, output);
+    positive(): Tensor {
+        return ops.positive(this);
     }
     /**
     * ![Plot of positive and its gradient](../../plots/positive.svg)
@@ -1841,7 +1841,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    positive_(output?: Tensor): Tensor {
+    positive_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1907,8 +1907,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    rad2deg(output?: Tensor): Tensor {
-        return ops.rad2deg(this, output);
+    rad2deg(): Tensor {
+        return ops.rad2deg(this);
     }
     /**
     * ![Plot of rad2deg and its gradient](../../plots/rad2deg.svg)
@@ -1925,7 +1925,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    rad2deg_(output?: Tensor): Tensor {
+    rad2deg_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1946,8 +1946,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    reciprocal(output?: Tensor): Tensor {
-        return ops.reciprocal(this, output);
+    reciprocal(): Tensor {
+        return ops.reciprocal(this);
     }
     /**
     * ![Plot of reciprocal and its gradient](../../plots/reciprocal.svg)
@@ -1964,7 +1964,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    reciprocal_(output?: Tensor): Tensor {
+    reciprocal_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -1985,8 +1985,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    relu(output?: Tensor): Tensor {
-        return ops.relu(this, output);
+    relu(): Tensor {
+        return ops.relu(this);
     }
     /**
     * ![Plot of relu and its gradient](../../plots/relu.svg)
@@ -2003,7 +2003,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    relu_(output?: Tensor): Tensor {
+    relu_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2024,8 +2024,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    round(output?: Tensor): Tensor {
-        return ops.round(this, output);
+    round(): Tensor {
+        return ops.round(this);
     }
     /**
     * ![Plot of round and its gradient](../../plots/round.svg)
@@ -2042,7 +2042,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    round_(output?: Tensor): Tensor {
+    round_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2063,8 +2063,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    rsqrt(output?: Tensor): Tensor {
-        return ops.rsqrt(this, output);
+    rsqrt(): Tensor {
+        return ops.rsqrt(this);
     }
     /**
     * ![Plot of rsqrt and its gradient](../../plots/rsqrt.svg)
@@ -2081,7 +2081,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    rsqrt_(output?: Tensor): Tensor {
+    rsqrt_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2102,8 +2102,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sigmoid(output?: Tensor): Tensor {
-        return ops.sigmoid(this, output);
+    sigmoid(): Tensor {
+        return ops.sigmoid(this);
     }
     /**
     * ![Plot of sigmoid and its gradient](../../plots/sigmoid.svg)
@@ -2120,7 +2120,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sigmoid_(output?: Tensor): Tensor {
+    sigmoid_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2141,8 +2141,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sign(output?: Tensor): Tensor {
-        return ops.sign(this, output);
+    sign(): Tensor {
+        return ops.sign(this);
     }
     /**
     * ![Plot of sign and its gradient](../../plots/sign.svg)
@@ -2159,7 +2159,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sign_(output?: Tensor): Tensor {
+    sign_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2180,8 +2180,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    silu(output?: Tensor): Tensor {
-        return ops.silu(this, output);
+    silu(): Tensor {
+        return ops.silu(this);
     }
     /**
     * ![Plot of silu and its gradient](../../plots/silu.svg)
@@ -2198,7 +2198,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    silu_(output?: Tensor): Tensor {
+    silu_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2219,8 +2219,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sin(output?: Tensor): Tensor {
-        return ops.sin(this, output);
+    sin(): Tensor {
+        return ops.sin(this);
     }
     /**
     * ![Plot of sin and its gradient](../../plots/sin.svg)
@@ -2237,7 +2237,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sin_(output?: Tensor): Tensor {
+    sin_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2258,8 +2258,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sinc(output?: Tensor): Tensor {
-        return ops.sinc(this, output);
+    sinc(): Tensor {
+        return ops.sinc(this);
     }
     /**
     * ![Plot of sinc and its gradient](../../plots/sinc.svg)
@@ -2276,7 +2276,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sinc_(output?: Tensor): Tensor {
+    sinc_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2297,8 +2297,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sinh(output?: Tensor): Tensor {
-        return ops.sinh(this, output);
+    sinh(): Tensor {
+        return ops.sinh(this);
     }
     /**
     * ![Plot of sinh and its gradient](../../plots/sinh.svg)
@@ -2315,7 +2315,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sinh_(output?: Tensor): Tensor {
+    sinh_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2336,8 +2336,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sqrt(output?: Tensor): Tensor {
-        return ops.sqrt(this, output);
+    sqrt(): Tensor {
+        return ops.sqrt(this);
     }
     /**
     * ![Plot of sqrt and its gradient](../../plots/sqrt.svg)
@@ -2354,7 +2354,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    sqrt_(output?: Tensor): Tensor {
+    sqrt_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2375,8 +2375,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    square(output?: Tensor): Tensor {
-        return ops.square(this, output);
+    square(): Tensor {
+        return ops.square(this);
     }
     /**
     * ![Plot of square and its gradient](../../plots/square.svg)
@@ -2393,7 +2393,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    square_(output?: Tensor): Tensor {
+    square_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2483,8 +2483,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    tan(output?: Tensor): Tensor {
-        return ops.tan(this, output);
+    tan(): Tensor {
+        return ops.tan(this);
     }
     /**
     * ![Plot of tan and its gradient](../../plots/tan.svg)
@@ -2501,7 +2501,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    tan_(output?: Tensor): Tensor {
+    tan_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2522,8 +2522,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    tanh(output?: Tensor): Tensor {
-        return ops.tanh(this, output);
+    tanh(): Tensor {
+        return ops.tanh(this);
     }
     /**
     * ![Plot of tanh and its gradient](../../plots/tanh.svg)
@@ -2540,7 +2540,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    tanh_(output?: Tensor): Tensor {
+    tanh_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };
@@ -2561,8 +2561,8 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    trunc(output?: Tensor): Tensor {
-        return ops.trunc(this, output);
+    trunc(): Tensor {
+        return ops.trunc(this);
     }
     /**
     * Alias for `trunc`.
@@ -2581,7 +2581,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    fix(output?: Tensor): Tensor {
+    fix(): Tensor {
         return ops.trunc(this);
     }
     /**
@@ -2599,7 +2599,7 @@ export class Tensor extends TensorBase {
     *
     * @returns the output tensor
     */
-    trunc_(output?: Tensor): Tensor {
+    trunc_(): Tensor {
         const params = {
             size: shapeSize(this.shape),
         };

--- a/web/benchmarks/benchmarkfw.js
+++ b/web/benchmarks/benchmarkfw.js
@@ -149,13 +149,13 @@ async function runBenchmarksAsync($benchmarksDiv) {
         $benchmarksTableRowName.innerText = b.key;
         $benchmarksTableRow.appendChild($benchmarksTableRowName);
         const $benchmarksTableRowTime = document.createElement('td');
-        $benchmarksTableRowTime.innerText = `${b.meanTime.toFixed(4)}`;
+        $benchmarksTableRowTime.innerText = `${b.meanTime.toFixed(3)}`;
         $benchmarksTableRow.appendChild($benchmarksTableRowTime);
         for (let ok of otherKeys) {
             const $benchmarksTableRowOther = document.createElement('td');
             if (otherResults[ok].results[b.key]) {
                 const ms = otherResults[ok].results[b.key].mean_ms;
-                $benchmarksTableRowOther.innerText = `${ms.toFixed(4)}`;
+                $benchmarksTableRowOther.innerText = `${ms.toFixed(3)}`;
             }
             $benchmarksTableRow.appendChild($benchmarksTableRowOther);
         }


### PR DESCRIPTION
This is a PR to fix the performance problem this library has so far suffered from.

Turns out, binding newly created buffers to WebGPU commands is expensive. You really want to reuse buffers not just to keep memory down, but also keep the GPU happy.

I tried a couple tricks:

* Pooled buffers but the browser garbage collector wasn't aggressive enough to free buffers.
* Sub buffers of large (max) size and a custom heap allocator but again the GC wasn't aggressive enough.

The heap allocator was the best, but the GC just wasn't freeing buffers fast enough for big computations.

Finally, I decided that the only way to make sure that buffers could be reused efficiently was to first compute the data flow graph and then translate that to SSA form, then from that check on the liveness of buffers. It's not so hard but is only worth it if the compute graph is more than a few nodes.

To enable growing large graphs, I have made tensors lazy be default. They only compute their value on demand - when `toArrayAsync()` is called or if the `storage` property is accessed. This is a big breaking change from how PyTorch works, but the performance gains are worth it.


### Eager evaluation benchmark

**32 GB** of memory

<table class="benchmarks"><thead><tr><th>Benchmark</th><th>Time (ms)</th><th>Intel(R) Xeon(R) W-2150B CPU @ 3.00GHz</th><th>NVIDIA GeForce RTX 3090</th><th>Error</th></tr></thead><tbody><tr><td>unary 1d(1, 'neg')</td><td>0.149</td><td>0.001</td><td>0.003</td><td></td></tr><tr><td>unary 1d(1, 'sigmoid')</td><td>0.146</td><td>0.001</td><td>0.003</td><td></td></tr><tr><td>unary 1d(729, 'neg')</td><td>0.155</td><td>0.001</td><td>0.003</td><td></td></tr><tr><td>unary 1d(729, 'sigmoid')</td><td>0.147</td><td>0.002</td><td>0.003</td><td></td></tr><tr><td>unary 1d(2187, 'neg')</td><td>0.164</td><td>0.002</td><td>0.003</td><td></td></tr><tr><td>unary 1d(2187, 'sigmoid')</td><td>0.153</td><td>0.004</td><td>0.003</td><td></td></tr><tr><td>unary 1d(59049, 'neg')</td><td>0.204</td><td>0.013</td><td>0.008</td><td></td></tr><tr><td>unary 1d(59049, 'sigmoid')</td><td>0.170</td><td>0.058</td><td>0.008</td><td></td></tr><tr><td>unary 1d(177147, 'neg')</td><td>0.773</td><td>0.073</td><td>0.017</td><td></td></tr><tr><td>unary 1d(177147, 'sigmoid')</td><td>0.168</td><td>0.177</td><td>0.017</td><td></td></tr><tr><td>unary 1d(531441, 'neg')</td><td>2.123</td><td>0.409</td><td>0.051</td><td></td></tr><tr><td>unary 1d(531441, 'sigmoid')</td><td>1.264</td><td>0.732</td><td>0.050</td><td></td></tr><tr><td>unary 1d(1594323, 'neg')</td><td>3.654</td><td>1.488</td><td>0.166</td><td></td></tr><tr><td>unary 1d(1594323, 'sigmoid')</td><td>3.030</td><td>2.344</td><td>0.157</td><td></td></tr></tbody></table>

### Lazy evaluation benchmark

**4 GB** of memory

<table class="benchmarks"><thead><tr><th>Benchmark</th><th>Time (ms)</th><th>Intel(R) Xeon(R) W-2150B CPU @ 3.00GHz</th><th>NVIDIA GeForce RTX 3090</th><th>Error</th></tr></thead><tbody><tr><td>unary 1d(1, 'neg')</td><td>0.030</td><td>0.001</td><td>0.003</td><td></td></tr><tr><td>unary 1d(1, 'sigmoid')</td><td>0.029</td><td>0.001</td><td>0.003</td><td></td></tr><tr><td>unary 1d(729, 'neg')</td><td>0.029</td><td>0.001</td><td>0.003</td><td></td></tr><tr><td>unary 1d(729, 'sigmoid')</td><td>0.029</td><td>0.002</td><td>0.003</td><td></td></tr><tr><td>unary 1d(2187, 'neg')</td><td>0.029</td><td>0.002</td><td>0.003</td><td></td></tr><tr><td>unary 1d(2187, 'sigmoid')</td><td>0.029</td><td>0.004</td><td>0.003</td><td></td></tr><tr><td>unary 1d(59049, 'neg')</td><td>0.031</td><td>0.013</td><td>0.008</td><td></td></tr><tr><td>unary 1d(59049, 'sigmoid')</td><td>0.031</td><td>0.058</td><td>0.008</td><td></td></tr><tr><td>unary 1d(177147, 'neg')</td><td>0.036</td><td>0.073</td><td>0.017</td><td></td></tr><tr><td>unary 1d(177147, 'sigmoid')</td><td>0.038</td><td>0.177</td><td>0.017</td><td></td></tr><tr><td>unary 1d(531441, 'neg')</td><td>0.048</td><td>0.409</td><td>0.051</td><td></td></tr><tr><td>unary 1d(531441, 'sigmoid')</td><td>0.050</td><td>0.732</td><td>0.050</td><td></td></tr><tr><td>unary 1d(1594323, 'neg')</td><td>0.089</td><td>1.488</td><td>0.166</td><td></td></tr><tr><td>unary 1d(1594323, 'sigmoid')</td><td>0.089</td><td>2.344</td><td>0.157</td><td></td></tr></tbody></table>