### PR TITLE
Show the GPU info in the benchmark output table

### DIFF
--- a/web/benchmarks/benchmarkfw.js
+++ b/web/benchmarks/benchmarkfw.js
@@ -42,7 +42,8 @@ async function runUnaryBenchmarkAsync(benchmark, inputs) {
         //     console.log("y1", yar);
         // }
         // await y.device._device.queue.onSubmittedWorkDone();
-        const end = performance.now();
+        const end = performance.now(
+);
         return (end - start) / benchmark.depth;
     }
     for (let i = 0; i < benchmark.warmupIterations; i++) {
@@ -86,7 +87,11 @@ async function runBenchmarksAsync($benchmarksDiv) {
     $benchmarksTable.appendChild($benchmarksTableHead);
     const $benchmarksTableHeadRow = document.createElement('tr');
     $benchmarksTableHead.appendChild($benchmarksTableHeadRow);
-    const hs = ['Benchmark', 'Time (ms)'];
+    
+    // Getting adapter info to set in the table
+    const adapter = await navigator.gpu?.requestAdapter();
+    const adapterInfo = adapter?.info?.description ?? 'Unknown GPU';
+    const hs = ['Benchmark', 'Time (ms) on ' + adapterInfo];
     for (let ok of otherKeys) {
         hs.push(otherResults[ok].device_name);
     }

--- a/web/benchmarks/benchmarkfw.js
+++ b/web/benchmarks/benchmarkfw.js
@@ -42,8 +42,7 @@ async function runUnaryBenchmarkAsync(benchmark, inputs) {
         //     console.log("y1", yar);
         // }
         // await y.device._device.queue.onSubmittedWorkDone();
-        const end = performance.now(
-);
+        const end = performance.now();
         return (end - start) / benchmark.depth;
     }
     for (let i = 0; i < benchmark.warmupIterations; i++) {


### PR DESCRIPTION
Show the GPU name/description in the column header. Sth like this:

| Benchmark                | Time (ms) on NVIDIA GeForce GTX 1060 3GB | Intel(R) Xeon(R) W-2150B CPU @ 3.00GHz | NVIDIA GeForce RTX 3090 | Error |
|--------------------------|------------------------------------------|---------------------------------------|-------------------------|-------|
| unary 1d(1, 'neg')       | 0.013                                    | 0.001                                 | 0.003                   |       |
| unary 1d(1, 'sigmoid')   | 0.012                                    | 0.001                                 | 0.003                   |       |
| unary 1d(729, 'neg')     | 0.018                                    | 0.001                                 | 0.003                   |       |
| unary 1d(729, 'sigmoid') | 0.010                                    | 0.002                                 | 0.003                   |       |
...
